### PR TITLE
feat: add win-icon feature flag to avoid winres conflicts with Tauri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libxdo-dev libglib2.0-dev
 
-      - name: Build CLI
-        run: cargo build --release
+      - name: Build CLI (with icon on Windows)
+        run: cargo build --release ${{ runner.os == 'Windows' && '--features win-icon' || '' }}
 
-      - name: Build GUI
-        run: cargo build --release --features gui
+      - name: Build GUI (with icon on Windows)
+        run: cargo build --release --features gui${{ runner.os == 'Windows' && ',win-icon' || '' }}
 
       - name: Run tests
         if: matrix.target != 'x86_64-apple-darwin'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exiftool-rs"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.71"
 description = "Read, write, and edit metadata in 93 file formats — a pure Rust reimplementation of ExifTool 13.53 with 100% tag name parity (194/194 test files)"
@@ -36,6 +36,7 @@ path = "src/lib.rs"
 [features]
 default = []
 gui = ["eframe", "egui", "image", "rfd", "noto-fonts-dl"]
+win-icon = []
 
 [dependencies]
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Each language includes 3230 translated tag descriptions plus all UI strings.
 
 | OS | Icon in binary | Notes |
 |----|---------------|-------|
-| **Windows** | Yes | Icon embedded in `.exe` via `winres` |
+| **Windows** | Opt-in | Icon embedded in `.exe` via `winres` when `win-icon` feature is enabled |
 | **macOS** | No | Requires a `.app` bundle with `.icns` |
 | **Linux** | No | ELF binaries don't support embedded icons |
 
@@ -220,9 +220,14 @@ cargo build --release
 
 # CLI + GUI
 cargo build --release --features gui
+
+# With Windows icon embedded in the .exe
+cargo build --release --features win-icon
 ```
 
 The `gui` feature is optional and not included by default. Without it, the GUI dependencies (egui, eframe, image, rfd, noto-fonts-dl) are not downloaded or compiled.
+
+The `win-icon` feature embeds an icon into the Windows `.exe` via `winres`. It is disabled by default to avoid conflicts with frameworks like Tauri that manage their own Windows resources.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", feature = "win-icon"))]
     {
         let mut res = winres::WindowsResource::new();
         res.set_icon("assets/icon.ico");


### PR DESCRIPTION
The Windows icon embedding via winres is now opt-in behind the
`win-icon` feature flag. This prevents build conflicts when the
crate is used as a library in frameworks like Tauri that manage
their own Windows resources.

Closes #2

https://claude.ai/code/session_016oQNREdxnfQiWjJuDTGvM1